### PR TITLE
Add token revocation service tests

### DIFF
--- a/simple_test.py
+++ b/simple_test.py
@@ -7,29 +7,33 @@ Tests basic Python container functionality without any dependencies.
 import time
 import sys
 
-print("🚀 Starting absolute minimal test...")
-print("✅ Python is working")
-print("📦 Container is running")
-print("⏰ Starting keep-alive loop...")
+def main() -> None:
+    """Run a very small keep-alive loop to prove the container works."""
+    print("🚀 Starting absolute minimal test...")
+    print("✅ Python is working")
+    print("📦 Container is running")
+    print("⏰ Starting keep-alive loop...")
 
-# Simple keep-alive loop
-try:
-    counter = 0
-    while True:
-        counter += 1
-        print(f"💗 Heartbeat {counter} - Container is alive")
-        time.sleep(30)
-        
-        # Exit after 10 minutes to prevent infinite loops
-        if counter > 20:
-            print("⏰ Test complete - Container worked successfully!")
-            break
-            
-except KeyboardInterrupt:
-    print("⏹️ Test stopped by user")
-except Exception as e:
-    print(f"❌ Error: {e}")
-    sys.exit(1)
+    try:
+        counter = 0
+        while True:
+            counter += 1
+            print(f"💗 Heartbeat {counter} - Container is alive")
+            time.sleep(30)
 
-print("✅ Test completed successfully")
-sys.exit(0) 
+            # Exit after 10 minutes to prevent infinite loops
+            if counter > 20:
+                print("⏰ Test complete - Container worked successfully!")
+                break
+    except KeyboardInterrupt:
+        print("⏹️ Test stopped by user")
+    except Exception as e:  # pragma: no cover - best effort safety
+        print(f"❌ Error: {e}")
+        sys.exit(1)
+
+    print("✅ Test completed successfully")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_token_revocation.py
+++ b/tests/test_token_revocation.py
@@ -1,0 +1,54 @@
+import asyncio
+import uuid
+import pytest
+
+try:
+    from revocation.token_revocation import TokenRevocationService
+except Exception:  # pragma: no cover - service may not be available
+    TokenRevocationService = None  # type: ignore
+
+
+
+
+
+def skip_if_service_missing():
+    if TokenRevocationService is None:
+        pytest.skip("TokenRevocationService not available")
+
+
+def get_service():
+    skip_if_service_missing()
+    return TokenRevocationService()
+
+
+def test_revoke_token():
+    service = get_service()
+    token = f"test-token-{uuid.uuid4()}"
+    async def run():
+        revocation_id = await service.revoke_token(token=token, reason="test", revoked_by="pytest")
+        assert revocation_id
+        assert await service.is_token_revoked(token)
+    asyncio.run(run())
+
+
+def test_bulk_revoke_tokens():
+    service = get_service()
+    tokens = [f"bulk-{i}-{uuid.uuid4()}" for i in range(3)]
+    async def run():
+        result = await service.bulk_revoke_tokens(tokens=tokens, server_id="test-server", reason="bulk")
+        assert result.get("revoked_count") == len(tokens)
+        statuses = await asyncio.gather(*[service.is_token_revoked(t) for t in tokens])
+        assert all(statuses)
+    asyncio.run(run())
+
+
+def test_get_revocation_status():
+    service = get_service()
+    token = f"status-{uuid.uuid4()}"
+    async def run():
+        revocation_id = await service.revoke_token(token=token, reason="status", revoked_by="pytest")
+        revocation = await service.get_revocation(revocation_id)
+        assert revocation is not None
+        assert getattr(revocation, "revocation_id", None) == revocation_id
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- add standalone TokenRevocationService tests using pytest
- guard `simple_test.py` so pytest doesn't execute it on import

## Testing
- `pytest tests/test_token_revocation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68454407961c832faf09232b70ba879a